### PR TITLE
Convert pubchem_mass to float

### DIFF
--- a/matchmsextras/pubchem_lookup.py
+++ b/matchmsextras/pubchem_lookup.py
@@ -324,7 +324,7 @@ def find_pubchem_mass_match(results_pubchem,
         if smiles_pubchem is None:
             smiles_pubchem = result.canonical_smiles
 
-        pubchem_mass = results_pubchem[0].exact_mass
+        pubchem_mass = float(results_pubchem[0].exact_mass)
         match_mass = (np.abs(pubchem_mass - parent_mass) <= mass_tolerance)
 
         if match_mass:


### PR DESCRIPTION
When trying to call `pubchem_metadata_lookup()`, the following error is being raised:

````

            pubchem_mass = results_pubchem[0].exact_mass
>           match_mass = (np.abs(pubchem_mass - parent_mass) <= mass_tolerance)
E           TypeError: unsupported operand type(s) for -: 'str' and 'float'

/Users/user/anaconda3/envs/omigami/lib/python3.7/site-packages/matchmsextras/pubchem_lookup.py:328: TypeError
````

This is happening because `results_pubchem[0].exact_mass` is a string and not a float.